### PR TITLE
Use __dirname instead of process.cwd()

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const path = require('path');
 module.exports = function () {
 	const isWindows = process.platform === 'win32';
 	const yarnPath = isWindows ? path.join('Yarn', 'config', 'global') : path.join('.config', 'yarn', 'global');
-	if (process.cwd().includes(yarnPath)) {
+	if (__dirname.includes(yarnPath)) {
 		return true;
 	}
 	return false;


### PR DESCRIPTION
As far as I can tell, using `process.cwd()` will not return the correct results.
If I include this in a CLI tool installed by yarn and run the command from `/home/rexxars/myproj`, that will be my cwd, whereas `__dirname` would return the directory name of the actual installed CLI tool.
